### PR TITLE
Loading  config file in debian distributions

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,7 +149,8 @@ overview but will differ from other distros.
 
 * `btrfs-*.sh` task scripts are expected at `/usr/share/btrfsmaintenance`
 * `sysconfig.btrfsmaintenance` configuration template is put to
-  `/etc/sysconfig/btrfsmaintenance`
+  `/etc/sysconfig/btrfsmaintenance` on RedHat based systems and to
+  `/etc/default/btrfsmaintenance` on Debian based systems.
 * `/usr/lib/zypp/plugins/commit/btrfs-defrag-plugin.py` post-update script for
   zypper (the package manager), applies to rpm-based distros now
 * cron refresh scripts are installed (see bellow)

--- a/btrfs-balance.sh
+++ b/btrfs-balance.sh
@@ -12,7 +12,11 @@ PATH=/sbin:/bin:/usr/sbin:/usr/bin
 export PATH
 
 if [ -f /etc/sysconfig/btrfsmaintenance ] ; then
-	. /etc/sysconfig/btrfsmaintenance
+    . /etc/sysconfig/btrfsmaintenance
+fi
+
+if [ -f /etc/default/btrfsmaintenance ] ; then
+    . /etc/default/btrfsmaintenance
 fi
 
 LOGIDENTIFIER='btrfs-balance'

--- a/btrfs-defrag.sh
+++ b/btrfs-defrag.sh
@@ -15,6 +15,10 @@ if [ -f /etc/sysconfig/btrfsmaintenance ] ; then
     . /etc/sysconfig/btrfsmaintenance
 fi
 
+if [ -f /etc/default/btrfsmaintenance ] ; then
+    . /etc/default/btrfsmaintenance
+fi
+
 LOGIDENTIFIER='btrfs-defrag'
 
 {

--- a/btrfs-scrub.sh
+++ b/btrfs-scrub.sh
@@ -15,6 +15,10 @@ if [ -f /etc/sysconfig/btrfsmaintenance ] ; then
     . /etc/sysconfig/btrfsmaintenance
 fi
 
+if [ -f /etc/default/btrfsmaintenance ] ; then
+    . /etc/default/btrfsmaintenance
+fi
+
 LOGIDENTIFIER='btrfs-scrub'
 
 readonly=

--- a/btrfs-trim.sh
+++ b/btrfs-trim.sh
@@ -15,6 +15,10 @@ if [ -f /etc/sysconfig/btrfsmaintenance ] ; then
     . /etc/sysconfig/btrfsmaintenance
 fi
 
+if [ -f /etc/default/btrfsmaintenance ] ; then
+    . /etc/default/btrfsmaintenance
+fi
+
 LOGIDENTIFIER='btrfs-trim'
 
 {


### PR DESCRIPTION
Hello I'm working on packaging this for Debian. One difference is that Debian uses /etc/default for things /etc/sysconfig is used for. 

This loads btrfsmaintenance config from either directory. The chances of having that file two times on the same OS is pretty slim. 

A better way to do it would be to source */etc/os-release* [1] and check ID_LIKE variable in a case. 

case "$ID_LIKE" in
 *rhel*)
  ;;
 *debian*)
  ;;
esac

[1] http://www.freedesktop.org/software/systemd/man/os-release.html