### PR TITLE
btrfsmaintenance-refresh-cron.sh: fix uninstall function

### DIFF
--- a/btrfsmaintenance-refresh-cron.sh
+++ b/btrfsmaintenance-refresh-cron.sh
@@ -19,7 +19,8 @@ SCRIPTS=/usr/share/btrfsmaintenance
 if [ "$1" = 'uninstall' ]; then
 	for SCRIPT in btrfs-scrub.sh btrfs-defrag.sh btrfs-balance.sh btrfs-trim.sh; do
 		for PERIOD in daily weekly monthly; do
-			FILE="/etc/cron.$PERIOD/$SCRIPT"
+			LINK="${SCRIPT%.*}"
+			FILE="/etc/cron.$PERIOD/$LINK"
 			rm -f "$FILE"
 		done
 	done


### PR DESCRIPTION
make uninstall subroutine compose cron-script symlink names the same way the
creation funtion does...

Signed-off-by: Martin Dummer <martin.dummer@gmx.net>