### PR TITLE
btrfs-*.sh: add new output destination "syslog" and minor enhancements

### DIFF
--- a/btrfs-balance.sh
+++ b/btrfs-balance.sh
@@ -54,6 +54,7 @@ case "$BTRFS_LOG_OUTPUT" in
 	stdout) cat;;
 	journal) systemd-cat -t "$LOGIDENTIFIER";;
 	syslog) logger -t "$LOGIDENTIFIER";;
+	none) cat >/dev/null;;
 	*) cat;;
 esac
 

--- a/btrfs-balance.sh
+++ b/btrfs-balance.sh
@@ -24,6 +24,7 @@ LOGIDENTIFIER='btrfs-balance'
 {
 OIFS="$IFS"
 IFS=:
+exec 2>&1 # redirect stderr to stdout to catch all output to log destination
 for MM in $BTRFS_BALANCE_MOUNTPOINTS; do
 	IFS="$OIFS"
 	if [ $(stat -f --format=%T "$MM") != "btrfs" ]; then

--- a/btrfs-balance.sh
+++ b/btrfs-balance.sh
@@ -53,6 +53,7 @@ done
 case "$BTRFS_LOG_OUTPUT" in
 	stdout) cat;;
 	journal) systemd-cat -t "$LOGIDENTIFIER";;
+	syslog) logger -t "$LOGIDENTIFIER";;
 	*) cat;;
 esac
 

--- a/btrfs-defrag.sh
+++ b/btrfs-defrag.sh
@@ -40,6 +40,7 @@ case "$BTRFS_LOG_OUTPUT" in
 	stdout) cat;;
 	journal) systemd-cat -t "$LOGIDENTIFIER";;
 	syslog) logger -t "$LOGIDENTIFIER";;
+	none) cat >/dev/null;;
 	*) cat;;
 esac
 

--- a/btrfs-defrag.sh
+++ b/btrfs-defrag.sh
@@ -39,6 +39,7 @@ done
 case "$BTRFS_LOG_OUTPUT" in
 	stdout) cat;;
 	journal) systemd-cat -t "$LOGIDENTIFIER";;
+	syslog) logger -t "$LOGIDENTIFIER";;
 	*) cat;;
 esac
 

--- a/btrfs-defrag.sh
+++ b/btrfs-defrag.sh
@@ -24,6 +24,7 @@ LOGIDENTIFIER='btrfs-defrag'
 {
 OIFS="$IFS"
 IFS=:
+exec 2>&1 # redirect stderr to stdout to catch all output to log destination
 for P in $BTRFS_DEFRAG_PATHS; do
 	IFS="$OIFS"
 	if [ $(stat -f --format=%T "$P") != "btrfs" ]; then

--- a/btrfs-scrub.sh
+++ b/btrfs-scrub.sh
@@ -55,6 +55,7 @@ case "$BTRFS_LOG_OUTPUT" in
 	stdout) cat;;
 	journal) systemd-cat -t "$LOGIDENTIFIER";;
 	syslog) logger -t "$LOGIDENTIFIER";;
+	none) cat >/dev/null;;
 	*) cat;;
 esac
 

--- a/btrfs-scrub.sh
+++ b/btrfs-scrub.sh
@@ -54,6 +54,7 @@ done
 case "$BTRFS_LOG_OUTPUT" in
 	stdout) cat;;
 	journal) systemd-cat -t "$LOGIDENTIFIER";;
+	syslog) logger -t "$LOGIDENTIFIER";;
 	*) cat;;
 esac
 

--- a/btrfs-scrub.sh
+++ b/btrfs-scrub.sh
@@ -35,6 +35,7 @@ fi
 {
 OIFS="$IFS"
 IFS=:
+exec 2>&1 # redirect stderr to stdout to catch all output to log destination
 for MNT in $BTRFS_SCRUB_MOUNTPOINTS; do
 	IFS="$OIFS"
 	echo "Running scrub on $MNT"

--- a/btrfs-trim.sh
+++ b/btrfs-trim.sh
@@ -40,6 +40,7 @@ case "$BTRFS_LOG_OUTPUT" in
 	stdout) cat;;
 	journal) systemd-cat -t "$LOGIDENTIFIER";;
 	syslog) logger -t "$LOGIDENTIFIER";;
+	none) cat >/dev/null;;
 	*) cat;;
 esac
 

--- a/btrfs-trim.sh
+++ b/btrfs-trim.sh
@@ -39,6 +39,7 @@ done
 case "$BTRFS_LOG_OUTPUT" in
 	stdout) cat;;
 	journal) systemd-cat -t "$LOGIDENTIFIER";;
+	syslog) logger -t "$LOGIDENTIFIER";;
 	*) cat;;
 esac
 

--- a/btrfs-trim.sh
+++ b/btrfs-trim.sh
@@ -24,6 +24,7 @@ LOGIDENTIFIER='btrfs-trim'
 {
 OIFS="$IFS"
 IFS=:
+exec 2>&1 # redirect stderr to stdout to catch all output to log destination
 for MNT in $BTRFS_TRIM_MOUNTPOINTS; do
 	IFS="$OIFS"
 	if [ $(stat -f --format=%T "$MNT") != "btrfs" ]; then

--- a/sysconfig.btrfsmaintenance
+++ b/sysconfig.btrfsmaintenance
@@ -1,8 +1,8 @@
 ## Path:        System/File systems/btrfs
-## Type:        string(none,stdout,journal)
+## Type:        string(none,stdout,journal,syslog)
 ## Default:     "stdout"
 #
-# Output target for messages. Journal messages are tagged by the task name like
+# Output target for messages. Journal and syslog messages are tagged by the task name like
 # 'btrfs-scrub' etc.
 BTRFS_LOG_OUTPUT="stdout"
 


### PR DESCRIPTION
For non-systemd distros it is desirable to have the output of the maintenance scripts send to the syslog daemon.