### PR TITLE
add filesystem autodetection keyword in config file

### DIFF
--- a/btrfs-balance.sh
+++ b/btrfs-balance.sh
@@ -20,8 +20,10 @@ if [ -f /etc/default/btrfsmaintenance ] ; then
 fi
 
 LOGIDENTIFIER='btrfs-balance'
+. $(dirname $0)/btrfsmaintenance-functions
 
 {
+evaluate_auto_mountpoint BTRFS_BALANCE_MOUNTPOINTS
 OIFS="$IFS"
 IFS=:
 exec 2>&1 # redirect stderr to stdout to catch all output to log destination

--- a/btrfs-scrub.sh
+++ b/btrfs-scrub.sh
@@ -34,7 +34,7 @@ if [ "$BTRFS_SCRUB_PRIORITY" = "normal" ]; then
 fi
 
 {
-evaluate_auto_mountpoint BTRFS_BALANCE_MOUNTPOINTS
+evaluate_auto_mountpoint BTRFS_SCRUB_MOUNTPOINTS
 OIFS="$IFS"
 IFS=:
 exec 2>&1 # redirect stderr to stdout to catch all output to log destination

--- a/btrfs-scrub.sh
+++ b/btrfs-scrub.sh
@@ -20,6 +20,7 @@ if [ -f /etc/default/btrfsmaintenance ] ; then
 fi
 
 LOGIDENTIFIER='btrfs-scrub'
+. $(dirname $0)/btrfsmaintenance-functions
 
 readonly=
 if [ "$BTRFS_SCRUB_READ_ONLY" = "true" ]; then
@@ -33,6 +34,7 @@ if [ "$BTRFS_SCRUB_PRIORITY" = "normal" ]; then
 fi
 
 {
+evaluate_auto_mountpoint BTRFS_BALANCE_MOUNTPOINTS
 OIFS="$IFS"
 IFS=:
 exec 2>&1 # redirect stderr to stdout to catch all output to log destination

--- a/btrfs-trim.sh
+++ b/btrfs-trim.sh
@@ -20,8 +20,10 @@ if [ -f /etc/default/btrfsmaintenance ] ; then
 fi
 
 LOGIDENTIFIER='btrfs-trim'
+. $(dirname $0)/btrfsmaintenance-functions
 
 {
+evaluate_auto_mountpoint BTRFS_BALANCE_MOUNTPOINTS
 OIFS="$IFS"
 IFS=:
 exec 2>&1 # redirect stderr to stdout to catch all output to log destination

--- a/btrfs-trim.sh
+++ b/btrfs-trim.sh
@@ -23,7 +23,7 @@ LOGIDENTIFIER='btrfs-trim'
 . $(dirname $0)/btrfsmaintenance-functions
 
 {
-evaluate_auto_mountpoint BTRFS_BALANCE_MOUNTPOINTS
+evaluate_auto_mountpoint BTRFS_TRIM_MOUNTPOINTS
 OIFS="$IFS"
 IFS=:
 exec 2>&1 # redirect stderr to stdout to catch all output to log destination

--- a/btrfsmaintenance-functions
+++ b/btrfsmaintenance-functions
@@ -1,0 +1,34 @@
+#!/bin/bash
+#
+# this file contains common code for the btrfs maintenance scripts
+#
+
+# function: evaluate_auto_mountpoint
+# parameter: A variable name
+#
+# this function checks whether the variable contains the special keyword "auto"
+# if yes, all currently mounted btrfs filesystems are evaluated and their mountpoints
+# are put into the parameter variable
+evaluate_auto_mountpoint() {
+	MOUNTPOINTSVAR=\$"$1"
+	if [ $(eval "expr \"$MOUNTPOINTSVAR\"") == "auto" ]; then
+		local BTRFS_DEVICES=""
+		local DEVICE=""
+		local MNT=""
+		local MNTLIST=""
+		# find all mounted btrfs filesystems, print their device nodes, sort them
+		# and remove identical entries
+		BTRFS_DEVICES=$(findmnt --types btrfs --output "SOURCE" --nofsroot --noheading | sort | uniq)
+		# find one (and only one) corresponding mountpoint for each btrfs device node
+		for DEVICE in $BTRFS_DEVICES; do
+			MNT=$(findmnt --types btrfs --first-only --noheadings --output "TARGET" --source "$DEVICE")
+			if [ -n "$MNTLIST" ]; then
+				MNTLIST="$MNTLIST:$MNT"
+			else
+				MNTLIST="$MNT"
+			fi
+		done
+		echo "evaluate mounted filesystems: $MNTLIST"
+		eval "$1=$MNTLIST"
+	fi
+}

--- a/sysconfig.btrfsmaintenance
+++ b/sysconfig.btrfsmaintenance
@@ -36,6 +36,7 @@ BTRFS_DEFRAG_MIN_SIZE="+1M"
 # Which mountpoints/filesystems to balance periodically. This may reclaim unused
 # portions of the filesystem and make the rest more compact.
 # (Colon separated paths)
+# The special word/mountpoint "auto" will evaluate all mounted btrfs filesystems at runtime
 BTRFS_BALANCE_MOUNTPOINTS="/"
 
 ## Path:           System/File systems/btrfs
@@ -74,6 +75,7 @@ BTRFS_BALANCE_MUSAGE="1 5 10 20 30"
 #
 # Which mountpoints/filesystems to scrub periodically.
 # (Colon separated paths)
+# The special word/mountpoint "auto" will evaluate all mounted btrfs filesystems at runtime
 BTRFS_SCRUB_MOUNTPOINTS="/"
 
 ## Path:        System/File systems/btrfs
@@ -117,4 +119,5 @@ BTRFS_TRIM_PERIOD="none"
 #
 # Which mountpoints/filesystems to trim periodically.
 # (Colon separated paths)
+# The special word/mountpoint "auto" will evaluate all mounted btrfs filesystems at runtime
 BTRFS_TRIM_MOUNTPOINTS="/"


### PR DESCRIPTION
This patch adds a special keyword "auto" as the path list which provides
a runtime btrfs detection instead of a static path list
The feature introduces a "btrfsmaintenance-functions" file to group
common code for btrfs-*.sh

Signed-off-by: Martin Dummer <martin.dummer@gmx.net>