### PR TITLE
fix path to functions

### DIFF
--- a/btrfs-balance.sh
+++ b/btrfs-balance.sh
@@ -20,7 +20,7 @@ if [ -f /etc/default/btrfsmaintenance ] ; then
 fi
 
 LOGIDENTIFIER='btrfs-balance'
-. $(dirname $0)/btrfsmaintenance-functions
+. $(dirname $(realpath $0))/btrfsmaintenance-functions
 
 {
 evaluate_auto_mountpoint BTRFS_BALANCE_MOUNTPOINTS


### PR DESCRIPTION
btrfsmaintenance-functions will not be found if btrfs-balance.sh is symlinked to /etc/cron.*