### PR TITLE
fix path to functions

### DIFF
--- a/btrfs-scrub.sh
+++ b/btrfs-scrub.sh
@@ -20,7 +20,7 @@ if [ -f /etc/default/btrfsmaintenance ] ; then
 fi
 
 LOGIDENTIFIER='btrfs-scrub'
-. $(dirname $0)/btrfsmaintenance-functions
+. $(dirname $(realpath $0))/btrfsmaintenance-functions
 
 readonly=
 if [ "$BTRFS_SCRUB_READ_ONLY" = "true" ]; then


### PR DESCRIPTION
btrfsmaintenance-functions will not be found if btrfs-scrub.sh is symlinked to /etc/cron.*