### PR TITLE
Replace check_mixed_bg with detect_mixed_bg

### DIFF
--- a/btrfs-balance.sh
+++ b/btrfs-balance.sh
@@ -37,7 +37,7 @@ for MM in $BTRFS_BALANCE_MOUNTPOINTS; do
 	btrfs filesystem df "$MM"
 	df -H "$MM"
 
-	if check_mixed_bg "$MM"; then
+	if detect_mixed_bg "$MM"; then
 		btrfs balance start -musage=0 -dusage=0 "$MM"
 		# we use the MUSAGE values for both, supposedly less aggressive
 		# values, but as the data and metadata space is shared on


### PR DESCRIPTION
There is no function with the name check_mixed_bg in btrfsmaintenance-functions defined. But right name is detect_mixed_bg