### PR TITLE
dash syntax fix

### DIFF
--- a/btrfsmaintenance-functions
+++ b/btrfsmaintenance-functions
@@ -11,7 +11,7 @@
 # are put into the parameter variable
 evaluate_auto_mountpoint() {
 	MOUNTPOINTSVAR=\$"$1"
-	if [ $(eval "expr \"$MOUNTPOINTSVAR\"") == "auto" ]; then
+	if [ "$(eval "expr \"$MOUNTPOINTSVAR\"")" = "auto" ]; then
 		local BTRFS_DEVICES=""
 		local DEVICE=""
 		local MNT=""


### PR DESCRIPTION
fix operator and prevent syntax error when variable is empty
should work with bash too.
fix #23 