### PR TITLE
Symlink update script not working in Ubuntu

### DIFF
--- a/btrfs-balance.sh
+++ b/btrfs-balance.sh
@@ -11,16 +11,16 @@ umask 022
 PATH=/sbin:/bin:/usr/sbin:/usr/bin
 export PATH
 
-if [ -f /etc/sysconfig/btrfsmaintenance ] ; then
-    . /etc/sysconfig/btrfsmaintenance
+if [ -f /etc/sysconfig/btrfsmaintenance/sysconfig.btrfsmaintenance ] ; then
+    . /etc/sysconfig/btrfsmaintenance/sysconfig.btrfsmaintenance
 fi
 
-if [ -f /etc/default/btrfsmaintenance ] ; then
-    . /etc/default/btrfsmaintenance
+if [ -f /etc/default/btrfsmaintenance/sysconfig.btrfsmaintenance ] ; then
+    . /etc/default/btrfsmaintenance/sysconfig.btrfsmaintenance
 fi
 
 LOGIDENTIFIER='btrfs-balance'
-. $(dirname $(realpath $0))/btrfsmaintenance-functions
+#. $(dirname $(realpath $0))/btrfsmaintenance-functions
 
 {
 evaluate_auto_mountpoint BTRFS_BALANCE_MOUNTPOINTS

--- a/btrfs-defrag.sh
+++ b/btrfs-defrag.sh
@@ -11,12 +11,12 @@ umask 022
 PATH=/sbin:/bin:/usr/sbin:/usr/bin
 export PATH
 
-if [ -f /etc/sysconfig/btrfsmaintenance ] ; then
-    . /etc/sysconfig/btrfsmaintenance
+if [ -f /etc/sysconfig/btrfsmaintenance/sysconfig.btrfsmaintenance ] ; then
+    . /etc/sysconfig/btrfsmaintenance/sysconfig.btrfsmaintenance
 fi
 
-if [ -f /etc/default/btrfsmaintenance ] ; then
-    . /etc/default/btrfsmaintenance
+if [ -f /etc/default/btrfsmaintenance/sysconfig.btrfsmaintenance ] ; then
+    . /etc/default/btrfsmaintenance/sysconfig.btrfsmaintenance
 fi
 
 LOGIDENTIFIER='btrfs-defrag'

--- a/btrfs-scrub.sh
+++ b/btrfs-scrub.sh
@@ -11,16 +11,16 @@ umask 022
 PATH=/sbin:/bin:/usr/sbin:/usr/bin
 export PATH
 
-if [ -f /etc/sysconfig/btrfsmaintenance ] ; then
-    . /etc/sysconfig/btrfsmaintenance
+if [ -f /etc/sysconfig/btrfsmaintenance/sysconfig.btrfsmaintenance ] ; then
+    . /etc/sysconfig/btrfsmaintenance/sysconfig.btrfsmaintenance
 fi
 
-if [ -f /etc/default/btrfsmaintenance ] ; then
-    . /etc/default/btrfsmaintenance
+if [ -f /etc/default/btrfsmaintenance/sysconfig.btrfsmaintenance ] ; then
+    . /etc/default/btrfsmaintenance/sysconfig.btrfsmaintenance
 fi
 
 LOGIDENTIFIER='btrfs-scrub'
-. $(dirname $(realpath $0))/btrfsmaintenance-functions
+#. $(dirname $(realpath $0))/btrfsmaintenance-functions
 
 readonly=
 if [ "$BTRFS_SCRUB_READ_ONLY" = "true" ]; then

--- a/btrfs-trim.sh
+++ b/btrfs-trim.sh
@@ -11,16 +11,16 @@ umask 022
 PATH=/sbin:/bin:/usr/sbin:/usr/bin
 export PATH
 
-if [ -f /etc/sysconfig/btrfsmaintenance ] ; then
-    . /etc/sysconfig/btrfsmaintenance
+if [ -f /etc/sysconfig/btrfsmaintenance/sysconfig.btrfsmaintenance ] ; then
+    . /etc/sysconfig/btrfsmaintenance/sysconfig.btrfsmaintenance
 fi
 
-if [ -f /etc/default/btrfsmaintenance ] ; then
-    . /etc/default/btrfsmaintenance
+if [ -f /etc/default/btrfsmaintenance/sysconfig.btrfsmaintenance ] ; then
+    . /etc/default/btrfsmaintenance/sysconfig.btrfsmaintenance
 fi
 
 LOGIDENTIFIER='btrfs-trim'
-. $(dirname $(realpath $0))/btrfsmaintenance-functions
+#. $(dirname $(realpath $0))/btrfsmaintenance-functions
 
 {
 evaluate_auto_mountpoint BTRFS_TRIM_MOUNTPOINTS

--- a/btrfsmaintenance-refresh-cron.sh
+++ b/btrfsmaintenance-refresh-cron.sh
@@ -27,12 +27,12 @@ if [ "$1" = 'uninstall' ]; then
 	exit 0
 fi
 
-if [ -f /etc/sysconfig/btrfsmaintenance ]; then
-    . /etc/sysconfig/btrfsmaintenance
+if [ -f /etc/sysconfig/btrfsmaintenance/sysconfig.btrfsmaintenance ]; then
+    . /etc/sysconfig/btrfsmaintenance/sysconfig.btrfsmaintenance
 fi
 
-if [ -f /etc/default/btrfsmaintenance ]; then
-    . /etc/default/btrfsmaintenance
+if [ -f /etc/default/btrfsmaintenance/sysconfig.btrfsmaintenance ]; then
+    . /etc/default/btrfsmaintenance/sysconfig.btrfsmaintenance
 fi
 
 refresh_period() {


### PR DESCRIPTION
The shell script would skip over both cases because the if statement was looking for a file. Adding the configuration file fixed the issue. Tested in Ubuntu 14.04