### PR TITLE
[defrag-plugin] Retrieve database path from RPM

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,8 +117,8 @@ for various types of data.
 __Special case:__
 
 There's a separate defragmentation task that happens automatically and
-defragments only the RPM database files in */var/lib/rpm*. This is done via a
-*zypper* plugin and the defrag pass triggers at the end of the installation.
+defragments only the RPM database files. This is done via a *zypper* plugin
+and the defrag pass triggers at the end of the installation.
 
 This improves reading the RPM databases later, but the installation process
 fragments the files very quickly so it's not likely to bring a significant

--- a/btrfs-defrag-plugin.py
+++ b/btrfs-defrag-plugin.py
@@ -2,9 +2,9 @@
 
 # This plugin defragments rpm files after update.
 #
-# If the filesystem is btrfs, run defrag command in /var/lib/rpm, set the
-# desired extent size to 64MiB, but this may change in the result depending
-# on the fragmentation of the free space
+# If the filesystem is btrfs, run defrag command in the RPM database
+# folder, set the desired extent size to 64MiB, but this may change in the
+# result depending on the fragmentation of the free space.
 #
 # Why 64MB:
 # - the worst fragmentation has been observed on Packages
@@ -24,7 +24,7 @@ import subprocess
 DEBUG=False
 EXTENT_SIZE=64*1024*1024
 LOGFILE='/tmp/btrfs-defrag-plugin.log'
-PATH='/var/lib/rpm'
+PATH=subprocess.check_output(["rpm", "--eval", "%_dbpath"]).strip()
 
 def dbg(args):
     if not DEBUG: return

--- a/btrfsmaintenance.spec
+++ b/btrfsmaintenance.spec
@@ -89,7 +89,12 @@ install -m 644 -D sysconfig.btrfsmaintenance %{buildroot}%{_localstatedir}/adm/f
 
 %preun
 %service_del_preun btrfsmaintenance-refresh.service
-%{_datadir}/%{name}/btrfsmaintenance-refresh-cron.sh uninstall
+if [ $1 -eq 0 ]; then
+  # Remove cron files in %%preun only if it's a package removal.
+  # If it's an upgrade, the %%post section of the new package has
+  # already refreshed the cron links, so we shall not remove them.
+  %{_datadir}/%{name}/btrfsmaintenance-refresh-cron.sh uninstall
+fi
 
 %postun
 %service_del_postun btrfsmaintenance-refresh.service
@@ -98,7 +103,9 @@ install -m 644 -D sysconfig.btrfsmaintenance %{buildroot}%{_localstatedir}/adm/f
 %if 0%{?suse_version} < 1210
 
 %preun
-%{_datadir}/%{name}/btrfsmaintenance-refresh-cron.sh uninstall
+if [ $1 -eq 0 ]; then
+  %{_datadir}/%{name}/btrfsmaintenance-refresh-cron.sh uninstall
+fi
 %endif
 
 %files


### PR DESCRIPTION
Recently, openSUSE has changed location of its RPM database from `/var/lib/rpm`
to `/usr/lib/sysimage/rpm` (#38).

`/var/lib/rpm` still exists but it's now a link to `/usr/lib/sysimage/rpm`.

It looks like `btrfs fi defragment -r` doesn't follow links, no defragmentation
is performed on the real location.

This commit fixes this by performing defragmentation on the real database
location retrieved from `rpm --eval %_dbpath`.