### PR TITLE
Add btrfsmaintenance-refresh.path

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,6 +175,10 @@ according to the configuration files. This can be called automatically by a GUI
 configuration tool if it's capable of running post-change scripts or services.
 In that case there's `btrfsmaintenance-refresh.service` systemd service.
 
+This service can also be automatically started upon any modification of the
+configuration file in `/etc/sysconfig/btrfsmaintenance` by installing the
+`btrfsmaintenance-refresh.path` systemd watcher.
+
 ### Post-update defragmentation ###
 
 The package database files tend to be updated in a random way and get

--- a/btrfsmaintenance-refresh.path
+++ b/btrfsmaintenance-refresh.path
@@ -1,0 +1,8 @@
+[Unit]
+Description=Watch /etc/sysconfig/btrfsmaintenance
+
+[Path]
+PathChanged=/etc/sysconfig/btrfsmaintenance
+
+[Install]
+WantedBy=multi-user.target

--- a/btrfsmaintenance-refresh.service
+++ b/btrfsmaintenance-refresh.service
@@ -7,4 +7,5 @@ ExecStart=/usr/share/btrfsmaintenance/btrfsmaintenance-refresh-cron.sh
 Type=oneshot
 
 [Install]
+Also=btrfsmaintenance-refresh.path
 WantedBy=multi-user.target


### PR DESCRIPTION
This is a monitoring unit. Upon any modification of `/etc/sysconfig/btrfsmaintenance`, this unit will start the `btrfsmaintenance-refresh.service`.

In other words, this allows to have timer periods automatically refreshed upon configuration change.