### PR TITLE
*.service switch to Type=simple systemd service

### DIFF
--- a/btrfs-balance.service
+++ b/btrfs-balance.service
@@ -4,7 +4,7 @@ Documentation=man:btrfs-balance
 After=fstrim.service btrfs-trim.service btrfs-scrub.service
 
 [Service]
-Type=oneshot
+Type=simple
 ExecStart=/usr/share/btrfsmaintenance/btrfs-balance.sh
 IOSchedulingClass=idle
 CPUSchedulingPolicy=idle

--- a/btrfs-defrag.service
+++ b/btrfs-defrag.service
@@ -4,7 +4,7 @@ Documentation=man:btrfs-filesystem
 After=fstrim.service btrfs-trim.service btrfs-scrub.service
 
 [Service]
-Type=oneshot
+Type=simple
 ExecStart=/usr/share/btrfsmaintenance/btrfs-defrag.sh
 IOSchedulingClass=idle
 CPUSchedulingPolicy=idle

--- a/btrfs-scrub.service
+++ b/btrfs-scrub.service
@@ -4,7 +4,7 @@ Documentation=man:fstrim
 After=fstrim.service btrfs-trim.service
 
 [Service]
-Type=oneshot
+Type=simple
 ExecStart=/usr/share/btrfsmaintenance/btrfs-scrub.sh
 IOSchedulingClass=idle
 CPUSchedulingPolicy=idle

--- a/btrfs-trim.service
+++ b/btrfs-trim.service
@@ -4,7 +4,7 @@ Documentation=man:fstrim
 Conflicts=fstrim.service
 
 [Service]
-Type=oneshot
+Type=simple
 ExecStart=/usr/share/btrfsmaintenance/btrfs-trim.sh
 IOSchedulingClass=idle
 CPUSchedulingPolicy=idle


### PR DESCRIPTION
Use Type=simple service, since btrfs actions can take a while, which
is in contradiction with oneshot systemd service type definition.