### PR TITLE
Protect strings on subshell/stat calls

### DIFF
--- a/btrfs-balance.sh
+++ b/btrfs-balance.sh
@@ -24,7 +24,7 @@ IFS=:
 exec 2>&1 # redirect stderr to stdout to catch all output to log destination
 for MM in $BTRFS_BALANCE_MOUNTPOINTS; do
 	IFS="$OIFS"
-	if [ "$(eval stat -f --format=%T \"$MM\")" != "btrfs" ]; then
+	if ! is_btrfs "$MM"; then
 		echo "Path $MM is not btrfs, skipping"
 		continue
 	fi

--- a/btrfs-balance.sh
+++ b/btrfs-balance.sh
@@ -24,7 +24,7 @@ IFS=:
 exec 2>&1 # redirect stderr to stdout to catch all output to log destination
 for MM in $BTRFS_BALANCE_MOUNTPOINTS; do
 	IFS="$OIFS"
-	if [ $(stat -f --format=%T "$MM") != "btrfs" ]; then
+	if [ "$(eval stat -f --format=%T \"$MM\")" != "btrfs" ]; then
 		echo "Path $MM is not btrfs, skipping"
 		continue
 	fi

--- a/btrfs-defrag.sh
+++ b/btrfs-defrag.sh
@@ -22,7 +22,7 @@ IFS=:
 exec 2>&1 # redirect stderr to stdout to catch all output to log destination
 for P in $BTRFS_DEFRAG_PATHS; do
 	IFS="$OIFS"
-	if [ $(stat -f --format=%T "$P") != "btrfs" ]; then
+	if [ "$(eval stat -f --format=%T \"$P\")" != "btrfs" ]; then
 		echo "Path $P is not btrfs, skipping"
 		continue
 	fi

--- a/btrfs-defrag.sh
+++ b/btrfs-defrag.sh
@@ -22,7 +22,7 @@ IFS=:
 exec 2>&1 # redirect stderr to stdout to catch all output to log destination
 for P in $BTRFS_DEFRAG_PATHS; do
 	IFS="$OIFS"
-	if [ "$(eval stat -f --format=%T \"$P\")" != "btrfs" ]; then
+	if ! is_btrfs "$P"; then
 		echo "Path $P is not btrfs, skipping"
 		continue
 	fi

--- a/btrfs-scrub.sh
+++ b/btrfs-scrub.sh
@@ -36,7 +36,7 @@ exec 2>&1 # redirect stderr to stdout to catch all output to log destination
 for MNT in $BTRFS_SCRUB_MOUNTPOINTS; do
 	IFS="$OIFS"
 	echo "Running scrub on $MNT"
-	if [ "$(eval stat -f --format=%T \"$MNT\")" != "btrfs" ]; then
+	if ! is_btrfs "$MNT"; then
 		echo "Path $MNT is not btrfs, skipping"
 		continue
 	fi

--- a/btrfs-scrub.sh
+++ b/btrfs-scrub.sh
@@ -36,7 +36,7 @@ exec 2>&1 # redirect stderr to stdout to catch all output to log destination
 for MNT in $BTRFS_SCRUB_MOUNTPOINTS; do
 	IFS="$OIFS"
 	echo "Running scrub on $MNT"
-	if [ $(stat -f --format=%T "$MNT") != "btrfs" ]; then
+	if [ "$(eval stat -f --format=%T \"$MNT\")" != "btrfs" ]; then
 		echo "Path $MNT is not btrfs, skipping"
 		continue
 	fi

--- a/btrfs-trim.sh
+++ b/btrfs-trim.sh
@@ -24,7 +24,7 @@ IFS=:
 exec 2>&1 # redirect stderr to stdout to catch all output to log destination
 for MNT in $BTRFS_TRIM_MOUNTPOINTS; do
 	IFS="$OIFS"
-	if [ $(stat -f --format=%T "$MNT") != "btrfs" ]; then
+	if [ "$(eval stat -f --format=%T \"$MNT\")" != "btrfs" ]; then
 		echo "Path $MNT is not btrfs, skipping"
 		continue
 	fi

--- a/btrfs-trim.sh
+++ b/btrfs-trim.sh
@@ -24,7 +24,7 @@ IFS=:
 exec 2>&1 # redirect stderr to stdout to catch all output to log destination
 for MNT in $BTRFS_TRIM_MOUNTPOINTS; do
 	IFS="$OIFS"
-	if [ "$(eval stat -f --format=%T \"$MNT\")" != "btrfs" ]; then
+	if ! is_btrfs "$MNT"; then
 		echo "Path $MNT is not btrfs, skipping"
 		continue
 	fi

--- a/btrfsmaintenance-functions
+++ b/btrfsmaintenance-functions
@@ -66,3 +66,13 @@ check_balance_running() {
 	fi
 	return 0
 }
+
+# function: is_btrfs
+# parameter: path to a mounted filesystem
+#
+# check if filesystem is a btrfs
+is_btrfs() {
+	local FS=$(stat -f --format=%T "$1")
+	[ "$FS" == "btrfs" ] && return 0
+	return 1
+}

--- a/btrfsmaintenance-functions
+++ b/btrfsmaintenance-functions
@@ -11,7 +11,7 @@
 # are put into the parameter variable
 evaluate_auto_mountpoint() {
 	MOUNTPOINTSVAR=\$"$1"
-	if [ "$(eval "expr \"$MOUNTPOINTSVAR\"")" = "auto" ]; then
+	if [ "$(eval expr \"$MOUNTPOINTSVAR\")" = "auto" ]; then
 		local BTRFS_DEVICES=""
 		local DEVICE=""
 		local MNT=""


### PR DESCRIPTION
All scripts create subshells and compare the resulting output string with construct like this:
```
if [ $(stat ... "$P") != "btrfs" ]; then
...
fi
```
this construct doesn't protect from empty strings obtaining a syntax error.

To solve, we must use "eval" in order to solve escaping and protect the result:

```
if [ "$(eval stat ... \"$P\")" != "btrfs" ]; then
...
fi
```
