### PR TITLE
Add Balance ionice idle priority

### DIFF
--- a/sysconfig.btrfsmaintenance
+++ b/sysconfig.btrfsmaintenance
@@ -51,6 +51,14 @@ BTRFS_BALANCE_MOUNTPOINTS="/"
 BTRFS_BALANCE_PERIOD="weekly"
 
 ## Path:        System/File systems/btrfs
+## Type:        string(idle,normal)
+## Default:     "idle"
+#
+# Priority of IO at which the balance process will run. Idle should not degrade
+# performance as much as normal.
+BTRFS_BALANCE_PRIORITY="normal"
+
+## Path:        System/File systems/btrfs
 ## Type:        string
 ## Default:     "1 5 10 20 30 40 50"
 #


### PR DESCRIPTION
Running balance makes a lot of IO- load, rendering most home office pcs useless for some minutes. This enhancement will make balance to use idle IO- Priority to lower the impact very much.