### PR TITLE
Prevent concurrent balance+defrag+scrub+trim (boo#1088010)

### DIFF
--- a/btrfs-balance.service
+++ b/btrfs-balance.service
@@ -5,6 +5,7 @@ After=fstrim.service btrfs-trim.service btrfs-scrub.service
 
 [Service]
 Type=simple
-ExecStart=/usr/share/btrfsmaintenance/btrfs-balance.sh
+SyslogIdentifier=btrfs-balance.sh
+ExecStart=/usr/bin/flock /run/btrfs-maintenance-running /usr/share/btrfsmaintenance/btrfs-balance.sh
 IOSchedulingClass=idle
 CPUSchedulingPolicy=idle

--- a/btrfs-defrag.service
+++ b/btrfs-defrag.service
@@ -5,6 +5,7 @@ After=fstrim.service btrfs-trim.service btrfs-scrub.service
 
 [Service]
 Type=simple
-ExecStart=/usr/share/btrfsmaintenance/btrfs-defrag.sh
+SyslogIdentifier=btrfs-defrag.sh
+ExecStart=/usr/bin/flock /run/btrfs-maintenance-running /usr/share/btrfsmaintenance/btrfs-defrag.sh
 IOSchedulingClass=idle
 CPUSchedulingPolicy=idle

--- a/btrfs-scrub.service
+++ b/btrfs-scrub.service
@@ -5,6 +5,7 @@ After=fstrim.service btrfs-trim.service
 
 [Service]
 Type=simple
-ExecStart=/usr/share/btrfsmaintenance/btrfs-scrub.sh
+SyslogIdentifier=btrfs-scrub.sh
+ExecStart=/usr/bin/flock /run/btrfs-maintenance-running /usr/share/btrfsmaintenance/btrfs-scrub.sh
 IOSchedulingClass=idle
 CPUSchedulingPolicy=idle

--- a/btrfs-trim.service
+++ b/btrfs-trim.service
@@ -5,6 +5,7 @@ Conflicts=fstrim.service
 
 [Service]
 Type=simple
-ExecStart=/usr/share/btrfsmaintenance/btrfs-trim.sh
+SyslogIdentifier=btrfs-trim.sh
+ExecStart=/usr/bin/flock /run/btrfs-maintenance-running /usr/share/btrfsmaintenance/btrfs-trim.sh
 IOSchedulingClass=idle
 CPUSchedulingPolicy=idle

--- a/btrfsmaintenance.spec
+++ b/btrfsmaintenance.spec
@@ -33,6 +33,7 @@ BuildRequires:  systemd
 Requires:       btrfsprogs
 Requires:       zypp-plugin-python
 Requires:       libzypp(plugin:commit)
+Requires:       util-linux
 Supplements:    btrfsprogs
 BuildArch:      noarch
 %{?systemd_requires}


### PR DESCRIPTION
When the services are triggered at the same time the access to the
physical devices is the limiting factor which can cause a severe
performance impact on the system.

The statements of "After=" do not prevent this when the services are
triggered individually, for example by the corresponding timer units,
hence they would start in parallel. Specifying a more fine-grained timer
schedule with selected operation windows will still trigger the services
at the same time when they could not be triggered earlier, for example
when the system was suspended so we need to handle the exclusive access
within the script calls.

Related bug: https://bugzilla.suse.com/show_bug.cgi?id=1088010