### PR TITLE
Wait for local-fs.target

### DIFF
--- a/btrfsmaintenance-refresh.path
+++ b/btrfsmaintenance-refresh.path
@@ -1,5 +1,6 @@
 [Unit]
 Description=Watch /etc/sysconfig/btrfsmaintenance
+After=local-fs.target
 
 [Path]
 PathChanged=/etc/sysconfig/btrfsmaintenance


### PR DESCRIPTION
Users report inconsistent behavior due to premature erroneous start of btrfsmaintenance-refresh.service:

https://forums.opensuse.org/showthread.php/539125-TW-after-update-to-20200211-My-user-hard-drive-partitions-do-not-get-mounted-at-boot-any-longer

 https://forums.opensuse.org/showthread.php/539503-boot-efi-is-not-mounted