### PR TITLE
Update btrfsmaintenance-refresh.service

### DIFF
--- a/btrfsmaintenance-refresh.service
+++ b/btrfsmaintenance-refresh.service
@@ -1,11 +1,9 @@
 [Unit]
 Description=Update cron periods from /etc/sysconfig/btrfsmaintenance
-After=local-fs.target
 
 [Service]
 ExecStart=/usr/share/btrfsmaintenance/btrfsmaintenance-refresh-cron.sh systemd-timer
 Type=oneshot
 
 [Install]
-Also=btrfsmaintenance-refresh.path
 WantedBy=multi-user.target


### PR DESCRIPTION
Deleted lines are not needed. They don't hurt either. But they may further misconceptions how the units work.

See: https://en.opensuse.org/SDB:Fix_btrfsmaintenance-refresh#Check_unit_files_for_correct_state