### PR TITLE
Delete install section

### DIFF
--- a/btrfsmaintenance-refresh.service
+++ b/btrfsmaintenance-refresh.service
@@ -1,6 +1,5 @@
 [Unit]
 Description=Update cron periods from /etc/sysconfig/btrfsmaintenance
-After=local-fs.target
 
 [Service]
 ExecStart=/usr/share/btrfsmaintenance/btrfsmaintenance-refresh-cron.sh systemd-timer


### PR DESCRIPTION
Install section causes the unit to execute during boot without  /etc/sysconfig/btrfsmaintenance being changed