### PR TITLE
Removed forced -dusage=0 and -musage=0 on non-mixed bg

### DIFF
--- a/btrfs-balance.sh
+++ b/btrfs-balance.sh
@@ -44,12 +44,11 @@ for MM in $BTRFS_BALANCE_MOUNTPOINTS; do
 			run_task btrfs balance start -v -musage=$BB -dusage=$BB "$MM"
 		done
 	else
-		run_task btrfs balance start -dusage=0 "$MM"
 		for BB in $BTRFS_BALANCE_DUSAGE; do
 			# quick round to clean up the unused block groups
 			run_task btrfs balance start -v -dusage=$BB "$MM"
 		done
-		run_task btrfs balance start -musage=0 "$MM"
+		
 		for BB in $BTRFS_BALANCE_MUSAGE; do
 			# quick round to clean up the unused block groups
 			run_task btrfs balance start -v -musage="$BB" "$MM"


### PR DESCRIPTION
As discussed on IRC, removed forced balancing of data and metadata, on non-mixed blockgroups case. This avoids always balancing metadata when user desire not to, for instance; same thing applies for data.

Script now applies strictly what's set on config file.