### PR TITLE
Add doc key to btrfsmaintenance-refresh.service

### DIFF
--- a/btrfsmaintenance-refresh.service
+++ b/btrfsmaintenance-refresh.service
@@ -1,5 +1,6 @@
 [Unit]
 Description=Update cron periods from /etc/sysconfig/btrfsmaintenance
+Documentation="file:/usr/share/doc/btrfsmaintenance/README.md.gz"
 
 [Service]
 ExecStart=/usr/share/btrfsmaintenance/btrfsmaintenance-refresh-cron.sh systemd-timer


### PR DESCRIPTION
This enables `systemctl help servicename` to function correctly by
displaying the documentation associated with the service.

Closes #83

Sorry for the delay, I had thought I had already created the PR.  Please let me know if SUSE systems don't compress READMEs and I'd be happy to s/README.md.gz/README.md/.