### PR TITLE
Added reset of OnCalendar for generated drop-in files

### DIFF
--- a/btrfsmaintenance-refresh-cron.sh
+++ b/btrfsmaintenance-refresh-cron.sh
@@ -74,6 +74,7 @@ refresh_timer() {
 			mkdir -p /etc/systemd/system/"$SERVICE".timer.d/
 			cat << EOF > /etc/systemd/system/"$SERVICE".timer.d/schedule.conf
 [Timer]
+OnCalendar=
 OnCalendar=$PERIOD
 EOF
 			systemctl enable "$SERVICE".timer &> /dev/null


### PR DESCRIPTION
Adds an empty OnCalendar line to the generated drop-in conf file. This fixes the linked issues where the default periods are used in addition to any periods provided in the btrfsmaintenance file.

Closes #91
Closes #71