### PR TITLE
Remove flock --verbose flag for CentOS 7 compatibility

### DIFF
--- a/btrfsmaintenance-functions
+++ b/btrfsmaintenance-functions
@@ -97,6 +97,6 @@ run_task() {
 	if test "$BTRFS_ALLOW_CONCURRENCY" = "true"; then
 		"$@"
 	else
-		/usr/bin/flock --verbose /run/btrfs-maintenance-running."$UUID" "$@"
+		/usr/bin/flock /run/btrfs-maintenance-running."$UUID" "$@"
 	fi
 }


### PR DESCRIPTION
CentOS 7 provides util-linux 2.23.2, its flock is too old to recognize `--verbose`.

Is it strictly necessary here?