### PR TITLE
btrfs-defrag: add -r option

### DIFF
--- a/btrfs-defrag.sh
+++ b/btrfs-defrag.sh
@@ -28,7 +28,7 @@ for P in $BTRFS_DEFRAG_PATHS; do
 		continue
 	fi
 	find "$P" -xdev -size "$BTRFS_DEFRAG_MIN_SIZE" -type f \
-		-exec btrfs filesystem defrag -t 32m -f $BTRFS_VERBOSITY '{}' \;
+		-exec btrfs filesystem defrag -r -t 32m -f $BTRFS_VERBOSITY '{}' \;
 done
 
 } | \


### PR DESCRIPTION
We specify the top-level directory in the btrfsmaintenance config file.
Why not add -r recursive option.

Signed-off-by: Anand Jain <anand.jain@oracle.com>