### PR TITLE
Add script to send mail in case btrfs issues were detected

### DIFF
--- a/btrfs-issuemail.service
+++ b/btrfs-issuemail.service
@@ -1,0 +1,7 @@
+[Unit]
+Description=Check for btrfs issues and send an email if any were found
+Documentation=man:btrfs
+
+[Service]
+Type=simple
+ExecStart=/usr/share/btrfsmaintenance/btrfs-issuemail.sh

--- a/btrfs-issuemail.sh
+++ b/btrfs-issuemail.sh
@@ -1,0 +1,82 @@
+#!/bin/bash
+#
+# Copyright (c) 2022 Matthias Klumpp <matthias@tenstral.net>
+
+umask 022
+PATH=/sbin:/bin:/usr/sbin:/usr/bin
+export PATH
+
+if [ -f /etc/sysconfig/btrfsmaintenance ] ; then
+    . /etc/sysconfig/btrfsmaintenance
+fi
+
+if [ -f /etc/default/btrfsmaintenance ] ; then
+    . /etc/default/btrfsmaintenance
+fi
+
+. $(dirname $(realpath "$0"))/btrfsmaintenance-functions
+
+if [ -z "$BTRFS_MAILADDR" ]
+then
+      # no email set, nothing to do for us
+      exit 0
+fi
+
+if ! command -v sendmail &> /dev/null
+then
+	echo "Failed to find sendmail, can not send emails about issues!" >/dev/stderr
+	exit 1
+fi
+
+ISSUE_MAIL_SENT_FILE="/run/btrfs-issue-mail-sent"
+if [ -f "$ISSUE_MAIL_SENT_FILE" ]; then
+	if [[ $(find "$ISSUE_MAIL_SENT_FILE" -mtime +1 -print) ]]; then
+		# delete issue sent file if it is older than a day, so
+		# we will send all notifications again
+		rm $ISSUE_MAIL_SENT_FILE
+	fi
+fi
+
+BTRFS_STATS_MOUNTPOINTS=$(expand_auto_mountpoint "auto")
+OIFS="$IFS"
+IFS=:
+for MM in $BTRFS_STATS_MOUNTPOINTS; do
+	if ! is_btrfs "$MM"; then
+		echo "Path $MM is not btrfs, skipping"
+		continue
+	fi
+	DEVSTATS=$(btrfs device stats --check $MM 2>&1)
+	if [ $? -ne 0 ]; then
+
+		if [ -f "$ISSUE_MAIL_SENT_FILE" ]; then
+			# check if we already sent an email
+			if grep -Fxq "$MM" "$ISSUE_MAIL_SENT_FILE"; then
+				# we've already mailed a report for issues on this
+				# mountpoint today, don't send another one just yet
+				continue
+			fi
+		fi
+
+		sendmail -t <<EOF
+To: $BTRFS_MAILADDR
+Subject: Btrfs device issue on $MM @ $HOSTNAME
+
+This is an automatically generated mail message from btrfs-issuemail
+running on $HOSTNAME
+
+An issue has been detected on the btrfs device mounted as $MM.
+
+Faithfully yours, etc.
+
+P.S. The 'btrfs device stats' output is:
+$DEVSTATS
+
+Filesystem usage:
+$(btrfs fi df $MM 2>&1)
+EOF
+		# set flag that we already sent a mail about this today
+		echo "$MM" >> $ISSUE_MAIL_SENT_FILE
+        fi
+done
+
+exit 0

--- a/btrfs-issuemail.sh
+++ b/btrfs-issuemail.sh
@@ -65,7 +65,7 @@ This is an automatically generated mail message from btrfs-issuemail
 running on $HOSTNAME
 
 An issue has been detected on the btrfs device mounted as $MM.
-
+You will be getting this email daily until you clear the issue with 'btrfs device stats --reset $MM'
 Faithfully yours, etc.
 
 P.S. The 'btrfs device stats' output is:

--- a/btrfs-issuemail.timer
+++ b/btrfs-issuemail.timer
@@ -1,0 +1,10 @@
+[Unit]
+Description=Check for btrfs issues and send mail if any were found
+Documentation=man:btrfs
+
+[Timer]
+OnCalendar=hourly
+Persistent=true
+
+[Install]
+WantedBy=timers.target

--- a/sysconfig.btrfsmaintenance
+++ b/sysconfig.btrfsmaintenance
@@ -152,3 +152,13 @@ BTRFS_TRIM_MOUNTPOINTS="/"
 # the timer for these tasks(s) elapsed while the system was suspended
 # or powered off.
 BTRFS_ALLOW_CONCURRENCY="false"
+
+## Path:	System/File systems/btrfs
+## Description:	Mail address to send issue reports to
+## Type: 	string
+## Default:	""
+#
+# If this is set to an email address or an username like "root", btrfs device stats
+# data will be checked every hour and an email will be sent to the given address
+# if any issues(like data corruption or read issues) were found.
+BTRFS_MAILADDR=""


### PR DESCRIPTION
Hi!
This PR adds an extremely basic script that just runs `btrfs device stats --check` on all btrfs filesystems every hour and sends an email to a user-defined address (most likely `root` in 90% of all cases) in case any issues were found.
This should very much work like the mdadm daemon feature that also sends mail in case one of the RAID members is about to fail.

A feature like this can be very useful for smaller setups where the admin still would
like to receive an email in case a disk in a btrfs RAID array fails.
This also is likely the billionth time someone has written such a script, so putting a version in one place where it can be shared and improved seemed like a good idea, and btrfsmaintenance seems to be the perfect place to add such a feature.

Thanks for considering this PR!