### PR TITLE
Fix function is_btrfs to cover <path|device> correctly. 

### DIFF
--- a/btrfsmaintenance-functions
+++ b/btrfsmaintenance-functions
@@ -72,7 +72,7 @@ check_balance_running() {
 #
 # check if filesystem is a btrfs
 is_btrfs() {
-	local FS=$(stat -f --format=%T "$1")
+	local FS=$(stat -f --format=%T $(df --output=target "$1")|tail -n1)
 	[ "$FS" = "btrfs" ] && return 0
 	return 1
 }

--- a/btrfsmaintenance-functions
+++ b/btrfsmaintenance-functions
@@ -72,7 +72,7 @@ check_balance_running() {
 #
 # check if filesystem is a btrfs
 is_btrfs() {
-	local FS=$(stat -f --format=%T $(df --output=target "$1")|tail -n1)
+	local FS=$(stat -f --format=%T $(df --output=target "$1"|tail -n1))
 	[ "$FS" = "btrfs" ] && return 0
 	return 1
 }


### PR DESCRIPTION
Currently, in the functions is_btrfs, stat -f will incorrectly report device paths because /dev/ is a virtual filesystem and classified as tmpfs.

Eg.

```
stat -f /dev/sdb 
  File: "/dev/sdb"
    ID: eb91af7d7bda02dd Namelen: 255     Type: tmpfs
Block size: 4096       Fundamental block size: 4096
Blocks: Total: 2012292    Free: 2012292    Available: 2012292
Inodes: Total: 2012292    Free: 2011839

```
This is correct behaviour for stat as according to the coreutils info docs:

>    "stat does not search for specified device nodes in the file system list, instead operating on them directly"

As the BTRFS documentation specifies <path|device> in all the commands, this is obviously undesirable behaviour for the is_btrfs function.

This patch uses df to work around the virtual nature of devices in Linux, while still retaining compatibility with paths.

Hope this helps.
