### PR TITLE
Switch btrfs-* services to Type=exec

### DIFF
--- a/btrfs-balance.service
+++ b/btrfs-balance.service
@@ -4,7 +4,7 @@ Documentation=man:btrfs-balance
 After=fstrim.service btrfs-trim.service btrfs-scrub.service
 
 [Service]
-Type=simple
+Type=exec
 ExecStart=/usr/share/btrfsmaintenance/btrfs-balance.sh
 IOSchedulingClass=idle
 CPUSchedulingPolicy=idle

--- a/btrfs-defrag.service
+++ b/btrfs-defrag.service
@@ -4,7 +4,7 @@ Documentation=man:btrfs-filesystem
 After=fstrim.service btrfs-trim.service btrfs-scrub.service
 
 [Service]
-Type=simple
+Type=exec
 ExecStart=/usr/share/btrfsmaintenance/btrfs-defrag.sh
 IOSchedulingClass=idle
 CPUSchedulingPolicy=idle

--- a/btrfs-scrub.service
+++ b/btrfs-scrub.service
@@ -4,7 +4,7 @@ Documentation=man:fstrim
 After=fstrim.service btrfs-trim.service
 
 [Service]
-Type=simple
+Type=exec
 ExecStart=/usr/share/btrfsmaintenance/btrfs-scrub.sh
 IOSchedulingClass=idle
 CPUSchedulingPolicy=idle

--- a/btrfs-trim.service
+++ b/btrfs-trim.service
@@ -4,7 +4,7 @@ Documentation=man:fstrim
 Conflicts=fstrim.service
 
 [Service]
-Type=simple
+Type=exec
 ExecStart=/usr/share/btrfsmaintenance/btrfs-trim.sh
 IOSchedulingClass=idle
 CPUSchedulingPolicy=idle

--- a/btrfsmaintenance-refresh.service
+++ b/btrfsmaintenance-refresh.service
@@ -5,7 +5,3 @@ After=local-fs.target
 [Service]
 ExecStart=/usr/share/btrfsmaintenance/btrfsmaintenance-refresh-cron.sh systemd-timer
 Type=oneshot
-
-[Install]
-Also=btrfsmaintenance-refresh.path
-WantedBy=multi-user.target

--- a/btrfsmaintenance-refresh.service
+++ b/btrfsmaintenance-refresh.service
@@ -1,6 +1,5 @@
 [Unit]
 Description=Update cron periods from /etc/sysconfig/btrfsmaintenance
-After=local-fs.target
 
 [Service]
 ExecStart=/usr/share/btrfsmaintenance/btrfsmaintenance-refresh-cron.sh systemd-timer


### PR DESCRIPTION
Type=simple causes trouble with After=... ordering of systemd services. Type=exec will repair ordering issue.