### PR TITLE
functions: fix run_task

### DIFF
--- a/btrfsmaintenance-functions
+++ b/btrfsmaintenance-functions
@@ -101,7 +101,7 @@ run_task() {
 	else
 		# Flock older than 2.27 does not support --verbose option, check
 		# if it's available as we'd like to log the information
-		if /usr/bin/flock --help 2>&1 | grep -q -- --verbose;
+		if /usr/bin/flock --help 2>&1 | grep -q -- --verbose; then
 			verbose="--verbose"
 		fi
 


### PR DESCRIPTION
The if statement was missing the then keyword, preventing any services to run.

## shellcheck
```
In /usr/share/btrfsmaintenance/btrfsmaintenance-functions line 101:
	else
        ^-- SC1009 (info): The mentioned syntax error was in this else clause.


In /usr/share/btrfsmaintenance/btrfsmaintenance-functions line 104:
		if /usr/bin/flock --help 2>&1 | grep -q -- --verbose;
                ^-- SC1049 (error): Did you forget the 'then' for this 'if'?
                ^-- SC1073 (error): Couldn't parse this if expression. Fix to allow more checks.


In /usr/share/btrfsmaintenance/btrfsmaintenance-functions line 106:
		fi
                ^-- SC1050 (error): Expected 'then'.
                  ^-- SC1072 (error): Unexpected keyword/token. Fix any mentioned problems and try again
```

## Fedora 40

```
#> systemctl status btrfs-scrub.service 
○ btrfs-scrub.service - Scrub btrfs filesystem, verify block checksums
     Loaded: loaded (/usr/lib/systemd/system/btrfs-scrub.service; static)
    Drop-In: /usr/lib/systemd/system/service.d
             └─10-timeout-abort.conf
     Active: inactive (dead) since Wed 2024-05-08 07:54:13 CEST; 7s ago
   Duration: 11ms
TriggeredBy: ● btrfs-scrub.timer
       Docs: man:fstrim
    Process: 19500 ExecStart=/usr/share/btrfsmaintenance/btrfs-scrub.sh (code=exited, status=0/SUCCESS)
   Main PID: 19500 (code=exited, status=0/SUCCESS)
        CPU: 10ms

Mai 08 07:54:13 THREADRIPPER-3970X.localdomain systemd[1]: Started btrfs-scrub.service - Scrub btrfs filesystem, verify block checksums.
Mai 08 07:54:13 THREADRIPPER-3970X.localdomain btrfs-scrub.sh[19500]: /usr/share/btrfsmaintenance/btrfsmaintenance-functions: line 106: syntax error near unexpected token `fi'
Mai 08 07:54:13 THREADRIPPER-3970X.localdomain btrfs-scrub.sh[19500]: /usr/share/btrfsmaintenance/btrfsmaintenance-functions: line 106: `                fi'
Mai 08 07:54:13 THREADRIPPER-3970X.localdomain btrfs-scrub.sh[19509]: Running scrub on /
Mai 08 07:54:13 THREADRIPPER-3970X.localdomain btrfs-scrub.sh[19509]: /usr/share/btrfsmaintenance/btrfs-scrub.sh: line 43: run_task: command not found
Mai 08 07:54:13 THREADRIPPER-3970X.localdomain btrfs-scrub.sh[19509]: Scrub cancelled at /
Mai 08 07:54:13 THREADRIPPER-3970X.localdomain systemd[1]: btrfs-scrub.service: Deactivated successfully.
```