### PR TITLE
Fix missing `then` in script

### DIFF
--- a/btrfsmaintenance-functions
+++ b/btrfsmaintenance-functions
@@ -101,7 +101,7 @@ run_task() {
 	else
 		# Flock older than 2.27 does not support --verbose option, check
 		# if it's available as we'd like to log the information
-		if /usr/bin/flock --help 2>&1 | grep -q -- --verbose;
+		if /usr/bin/flock --help 2>&1 | grep -q -- --verbose; then
 			verbose="--verbose"
 		fi
 


### PR DESCRIPTION
There is a syntax error that causes a line in the `btrfsmaintenance-functions` to crash under certain circumstances. See #120 for more details. This fixes it by adding in a `; then` after the line.

Edit: #119