### PR TITLE
Add missing 'then'

### DIFF
--- a/btrfsmaintenance-functions
+++ b/btrfsmaintenance-functions
@@ -101,7 +101,7 @@ run_task() {
 	else
 		# Flock older than 2.27 does not support --verbose option, check
 		# if it's available as we'd like to log the information
-		if /usr/bin/flock --help 2>&1 | grep -q -- --verbose;
+		if /usr/bin/flock --help 2>&1 | grep -q -- --verbose; then
 			verbose="--verbose"
 		fi
 


### PR DESCRIPTION
Fixes issue when run_task couldn't be properly sourced due to shellcheck SC1049 (missing then after if)