### PR TITLE
Use Systemd-provided cgroup IO limits

### DIFF
--- a/README.man
+++ b/README.man
@@ -63,6 +63,10 @@ you can turn off the automatic repair (\fB\fCBTRFS\_SCRUB\_READ\_ONLY\fR)
 .IP \(bu 2
 the default IO priority is set to \fIidle\fP but scrub may take long to finish,
 you can change priority to \fInormal\fP (\fB\fCBTRFS\_SCRUB\_PRIORITY\fR)
+.IP \(bu 2
+If using systemd timers, you can also enable (`BTRFS_IO_LIMIT`) to set IO resource
+.IP \(bu 2
+limits
 
 .RE
 

--- a/README.md
+++ b/README.md
@@ -46,6 +46,8 @@ __Tuning:__
 * you can turn off the automatic repair (`BTRFS_SCRUB_READ_ONLY`)
 * the default IO priority is set to *idle* but scrub may take long to finish,
   you can change priority to *normal* (`BTRFS_SCRUB_PRIORITY`)
+* If using systemd timers, you can also enable (`BTRFS_IO_LIMIT`) to set IO resource
+* limits
 
 __Related commands:__
 

--- a/btrfsmaintenance-refresh-cron.sh
+++ b/btrfsmaintenance-refresh-cron.sh
@@ -84,6 +84,20 @@ OnCalendar=$PERIOD
 EOF
 			systemctl enable "$SERVICE".timer &> /dev/null
 			systemctl start "$SERVICE".timer &> /dev/null
+			OIFS="$IFS"
+			IFS=:
+      if [ "$BTRFS_IO_LIMIT" = "true" ] ; then
+			  mkdir -p /etc/systemd/system/"$SERVICE".service.d
+				echo '[Service]' > /etc/systemd/system/"$SERVICE".service.d/10-iolimits.conf
+				for DEVICE in $BTRFS_IO_LIMIT_DEVICES ; do
+				  echo "IOReadBandwidthMax=$DEVICE $BTRFS_IO_LIMIT_BW"
+				  echo "IOWriteBandwidthMax=$DEVICE $BTRFS_IO_LIMIT_BW"
+				  echo "IOReadIOPSMax=$DEVICE $BTRFS_IO_LIMIT_IOPS"
+				  echo "IOWriteIOPSMax=$DEVICE $BTRFS_IO_LIMIT_IOPS"
+				done >> /etc/systemd/system/"$SERVICE".service.d/10-iolimits.conf
+				systemctl daemon-reload
+			fi
+			IFS="$OIFS"
 			;;
 	esac
 }

--- a/sysconfig.btrfsmaintenance
+++ b/sysconfig.btrfsmaintenance
@@ -152,3 +152,39 @@ BTRFS_TRIM_MOUNTPOINTS="/"
 # the timer for these tasks(s) elapsed while the system was suspended
 # or powered off.
 BTRFS_ALLOW_CONCURRENCY="false"
+
+## Path:        System/File systems/btrfs
+## Description:	Configuration to allow limiting bandwidth and IOPS
+## Type: 	boolean
+## Default:	"false"
+# Maintenance tasks may starve system resources for other more urgent
+# workloads. This enables IO resource limits when using systemd timers.
+BTRFS_IO_LIMIT="false"
+
+## Path:        System/File systems/btrfs
+## Description:	Configuration to specify devices with limited bandwidth and/or IOPS
+## Type: 	string
+## Default:	"/dev/sda"
+# With IO resource limits, this setting specifies the block devices that will
+# have resource limits set
+# (Colon separated paths)
+BTRFS_IO_LIMIT_DEVICES="/dev/sda"
+
+## Path:        System/File systems/btrfs
+## Description:	Configuration to specify IOPS limits
+## Type: 	string
+## Default:	"40"
+# With IO resource limits, this setting specifies the per-device IOPS limits.
+# SSDs can typically perform thousands of operations per second while spindles
+# can only perform up to 120 IOPS, though with terrible throughput.
+BTRFS_IO_LIMIT_IOPS="40"
+
+## Path:        System/File systems/btrfs
+## Description:	Configuration to specify disk bandwidth limits
+## Type: 	string
+## Default:	"20M"
+# With IO resource limits, this setting specifies the per-device bandwidth
+# limit. The typical maximum speed of SATA SSDs is about 550MBps limited by
+# the SATA protocol. Current high-end spindle drives' typical maximum speed
+# is about 240MBps.
+BTRFS_IO_LIMIT_BW="20M"


### PR DESCRIPTION
Maintenance tasks may starve system IO resources for other more urgent workloads. This PR enables cgroup IO resource limits when using systemd timers.

Notes:

* This needs some testing especially on other distributions. I've tested this with balance operations in Fedora 40 `(systemd 255.10-3.fc40)`.
* This works for systemd but I'm not sure how best to achieve the same for cron. Wrapping systemd-run seems redundant since it technically temporarily creates a service for each run.
* I am not sure if the defaults I have suggested are good. I have based these defaults on the limits I feel would be appropriate for spindles where I expect high IO demand for non-maintenance services and I don't mind if the maintenance tasks take a very long time to complete.
* I am not sure if there is a good way to configure different limits for different disk classes. For example if you have a RAID1 OS filesystem on SSD and a large RAID5 backup filesystem on spindles, it would be useful to be able to have different sets of IO limits.

To view these cgroup limits in action outside of a regular service, you can wrap a command with `systemd-run`. For example, the following is a balance with -musage=30 on a two-disk filesystem on /dev/dm-0 and /dev/dm-1, with IOPS limits of 60 and bandwidth of 10MBps:

    $ systemd-run --property="IOReadBandwidthMax=/dev/dm-0 10M" --property="IOWriteBandwidthMax=/dev/dm-0 10M" --property="IOReadIOPSMax=/dev/dm-0 60" --property="IOWriteIOPSMax=/dev/dm-0 60" --property="IOReadBandwidthMax=/dev/dm-1 10M" --property="IOWriteBandwidthMax=/dev/dm-1 10M" --property="IOReadIOPSMax=/dev/dm-1 60" --property="IOWriteIOPSMax=/dev/dm-1 60" btrfs balance start -musage=30 /
    Running as unit: run-r0fa03384626b4245b07857fc38089744.service; invocation ID: 7869d843bd814cb7bc1e5db9d35bc46f
    $ cat /sys/fs/cgroup/system.slice/run-r0fa03384626b4245b07857fc38089744.service/io.max
    252:0 rbps=10000000 wbps=10000000 riops=60 wiops=max
    252:128 rbps=10000000 wbps=10000000 riops=60 wiops=max
    $ cat /sys/fs/cgroup/system.slice/run-r0fa03384626b4245b07857fc38089744.service/io.stat
    253:6 rbytes=1114112 wbytes=15321464832 rios=68 wios=117555 dbytes=0 dios=0
    .... many similar lines here in my system
    $ journalctl -u run-r0fa03384626b4245b07857fc38089744.service
    Aug 25 15:55:25 <hostname> systemd[1]: Started run-r0fa03384626b4245b07857fc38089744.service - /usr/sbin/btrfs balance start -musage=30 /.
    Aug 25 15:55:52 <hostname> btrfs[86830]: Done, had to relocate 3 out of 12787 chunks
    Aug 25 15:55:52 <hostname> systemd[1]: run-r0fa03384626b4245b07857fc38089744.service: Deactivated successfully.
    Aug 25 15:55:52 <hostname> systemd[1]: run-r0fa03384626b4245b07857fc38089744.service: Consumed 17.403s CPU time.

Further to the above example, if I run `lsblk` it shows the corresponding device IDs `252:0` and `252:128` for `dm-0` and `dm-1` respectively.