### PR TITLE
two patches for btrfsmaintenance

### DIFF
--- a/btrfsmaintenance-refresh-cron.sh
+++ b/btrfsmaintenance-refresh-cron.sh
@@ -11,9 +11,25 @@ export PATH
 
 SCRIPTS=/usr/share/btrfsmaintenance
 
-if [ -f /etc/sysconfig/btrfsmaintenance ]; then
-    . /etc/sysconfig/btrfsmaintenance
-fi
+# here we will try three times (by sleeping 1s) to check if
+# the configuration file exists.
+TRY_TIMES=0
+while [ $TRY_TIMES -lt 3 ]; do
+    if [ ! -f /etc/sysconfig/btrfsmaintenance ]; then
+        sleep 1
+    else
+        break
+    fi
+    ((TRY_TIMES++))
+    if [ $TRY_TIMES -eq 3 ];then
+		echo "Failed to find configuration file /etc/sysconfig/btrfsmaintenance"
+        exit 1
+    else
+        continue
+    fi
+done
+
+. /etc/sysconfig/btrfsmaintenance
 
 if [ -f /etc/default/btrfsmaintenance ]; then
     . /etc/default/btrfsmaintenance

--- a/sysconfig.btrfsmaintenance
+++ b/sysconfig.btrfsmaintenance
@@ -52,7 +52,7 @@ BTRFS_BALANCE_MOUNTPOINTS="/"
 # The frequency may be specified using one of the listed values or
 # in the format documented in the "Calendar Events" section of systemd.time(7),
 # if available.
-BTRFS_BALANCE_PERIOD="weekly"
+BTRFS_BALANCE_PERIOD="monthly"
 
 ## Path:        System/File systems/btrfs
 ## Type:        string


### PR DESCRIPTION
For the first  patch, when this package was first installed, the timer will be scheduled as monthly for btrfs-balance.service. However if the user modifies configuration options other than BTRFS_BALANCE_PERIOD in /etc/sysconfig/btrfsmaintenance, the timer will be changed to weekly without being noticed. To avoid such a case, it's better to keep the value in the .timer file and the configuration file same.
For the second patch, it tries to fix a timing window when editing the configuration file /etc/sysconfig/btrfsmaintenance. Please refer to the patch description for more detail.