### PR TITLE
Use expand_auto_mountpoint in btrfs-defrag.sh

### DIFF
--- a/btrfs-defrag.sh
+++ b/btrfs-defrag.sh
@@ -18,6 +18,7 @@ LOGIDENTIFIER='btrfs-defrag'
 . $(dirname $(realpath "$0"))/btrfsmaintenance-functions
 
 {
+BTRFS_DEFRAG_PATHS=$(expand_auto_mountpoint "$BTRFS_DEFRAG_PATHS")
 OIFS="$IFS"
 IFS=:
 exec 2>&1 # redirect stderr to stdout to catch all output to log destination

--- a/sysconfig.btrfsmaintenance
+++ b/sysconfig.btrfsmaintenance
@@ -14,6 +14,8 @@ BTRFS_LOG_OUTPUT="stdout"
 # cross mount points or other subvolumes/snapshots. If you want to defragment
 # nested subvolumes, all have to be listed in this variable.
 # (Colon separated paths)
+# The special word/mountpoint "auto" will evaluate all mounted btrfs
+# filesystems
 BTRFS_DEFRAG_PATHS=""
 
 ## Path:           System/File systems/btrfs


### PR DESCRIPTION
Copy a single line from btrfs-balance.sh/btrfs-scrub.sh/btrfs-trim.sh to also be in btrfs-defrag.sh which allows for automatically detecting all mounted btrfs filesystems. This allows them to be defragged with the following configuration:

`BTRFS_DEFRAG_PATHS="auto"`

This change was documented in the file `sysconfig.btrfsmaintenance` for users.

Closes https://github.com/kdave/btrfsmaintenance/issues/131